### PR TITLE
Remove Documenter and Setfield deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,6 @@ version = "0.2.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
@@ -21,10 +19,8 @@ JacobiEllipticZygoteExt = "Zygote"
 
 [compat]
 DocStringExtensions = "0.9"
-Documenter = "1.1"
 Enzyme = "0.11, 0.12"
-Zygote = "0.6"
 ForwardDiff = "0.10"
-Setfield = "1.1"
 StaticArrays = "1.6"
+Zygote = "0.6"
 julia = "1.8"

--- a/src/Carlson.jl
+++ b/src/Carlson.jl
@@ -8,7 +8,6 @@ export Jacobi
 # matlab compatible
 export ellipj, ellipke
 
-import Setfield
 include("jacobi.jl")
 include("slatec.jl")
 

--- a/src/Fukushima.jl
+++ b/src/Fukushima.jl
@@ -1,5 +1,5 @@
 module FukushimaAlg
-using StaticArrays, Setfield
+using StaticArrays
 
 export K, E, F, Pi, J
 export sn, cn, dn, sc, sd, asn, acn
@@ -383,7 +383,7 @@ end
 function Ds(s::A, m::B) where {A,B}
     T = promote_type(A,B)
     #Pre-allocate with SVector to avoid GPU allocations
-	_ybuf = StaticArrays.@SVector[zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T)]
+	_ybuf = StaticArrays.@MVector[zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T)]
 
 	y0 = s^2
 	yi = y0
@@ -393,7 +393,7 @@ function Ds(s::A, m::B) where {A,B}
 	for _ in 1:10
 		yi < yA(m) && break
 		I += 1
-		Setfield.@set! _ybuf[I] = yi
+		@inbounds _ybuf[I] = yi
 
 		ci = √(one(T) - yi)
 		di = √(one(T) - m * yi)
@@ -405,7 +405,7 @@ function Ds(s::A, m::B) where {A,B}
 	Di = D0
 
 	for i in I:-1:1
-		yim1 = _ybuf[i]
+		@inbounds yim1 = _ybuf[i]
 		sim1 = √yim1
 
 		Di = 2Di + sim1 * yi
@@ -738,7 +738,7 @@ end
 function Js(n::A, s::B, m::C) where {A,B,C}
     T = promote_type(A,B,C)
     #Pre-allocate with SVector to avoid GPU allocations
-    _ybuf = StaticArrays.@SVector[zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T)]
+    _ybuf = StaticArrays.@MVector[zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T)]
 
     nc = one(T) - n
     h = n*nc*(n-m)
@@ -752,7 +752,7 @@ function Js(n::A, s::B, m::C) where {A,B,C}
     for _ in 1:10
         yi < yB && break
         I += 1
-        Setfield.@set! _ybuf[I] = yi
+        _ybuf[I] = yi
 
         ci = √(one(T)-yi)
         di = √(one(T)-m*yi)
@@ -765,7 +765,7 @@ function Js(n::A, s::B, m::C) where {A,B,C}
     ti = zero(T)
     
     for i in I:-1:1
-        yim1 = _ybuf[i]
+        @inbounds yim1 = _ybuf[i]
         sim1 = √yim1
         cim1 = √(one(T)-yim1)
         dim1 = √(one(T)-m*yim1)

--- a/src/Fukushima.jl
+++ b/src/Fukushima.jl
@@ -752,7 +752,7 @@ function Js(n::A, s::B, m::C) where {A,B,C}
     for _ in 1:10
         yi < yB && break
         I += 1
-        _ybuf[I] = yi
+        @inbounds _ybuf[I] = yi
 
         ci = √(one(T)-yi)
         di = √(one(T)-m*yi)

--- a/src/JacobiElliptic.jl
+++ b/src/JacobiElliptic.jl
@@ -1,5 +1,5 @@
 module JacobiElliptic
-using StaticArrays, Setfield
+using StaticArrays
 using DocStringExtensions
 
 @template (FUNCTIONS, METHODS, MACROS) =

--- a/src/jacobi.jl
+++ b/src/jacobi.jl
@@ -14,7 +14,7 @@ function _am(u::A, m::B, tol::C) where {A,B,C}
     T = promote_type(A, B, C)
 
     #Pre-allocate with SVector to avoid GPU allocations
-    _ambuf = StaticArrays.@SVector[zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T)]
+    _ambuf = StaticArrays.@MVector[zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T),zero(T)]
     u == 0 && return zero(T)
 
     sqrt_tol = sqrt(tol)
@@ -33,13 +33,13 @@ function _am(u::A, m::B, tol::C) where {A,B,C}
     while abs(c) > tol
         @assert n < 10
         a,b,c,n = ((a+b)/2, sqrt(a*b), (a-b)/2, n+1)
-        Setfield.@set! _ambuf[n] = c/a
+        @inbounds _ambuf[n] = c/a
     end
 
     #phi = ldexp(a*u, n) # Doesn't work with Enzyme
     phi = a*u*(2^n)
     for i = n:-1:1
-        phi = (phi + asin(_ambuf[i]*sin(phi)))/2
+        @inbounds phi = (phi + asin(_ambuf[i]*sin(phi)))/2
     end
     phi
 end


### PR DESCRIPTION
I noticed that JacobiElliptic depended on Documenter. Typically, packages don't directly depend on Documenter since it is a heavy dependency. I've removed that since it doesn't appear it was used for anything.

Additionally, I noticed that Setfield was solely being used for changing a SVector in a couple of spots in the code. I've removed the need for that by switching to an MVector and throwing in a couple of inbounds. In newer Julia versions, if the MVector doesn't escape the function (i.e. not returned) then there typically is no allocation. I've checked this locally and don't see any allocations. Plus, at least locally, removing the `@set` seems to speed up the code slightly. 

After this PR

```julia
BenchmarkTools.Trial: 10000 samples with 996 evaluations.
 Range (min … max):  25.163 ns … 39.163 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     25.326 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   25.443 ns ±  0.508 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▅█▆  ▁▄▃         ▂                ▁                       ▁
  ▅▇████▆███▆▄▃▁▃▁▃▁▇█▇▁▁▆▇▄▁▁▁▄▃▆▆▆▇██▇▇▆▆▄▅▅▅▅▆▅▅▅▄▄▅█▆▃▁▄▄ █
  25.2 ns      Histogram: log(frequency) by time      27.7 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Before this PR

```julia
BenchmarkTools.Trial: 10000 samples with 995 evaluations.
 Range (min … max):  26.741 ns … 45.222 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     26.808 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   26.932 ns ±  0.561 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅█▄ ▄▅            ▁                                         ▁
  ███████▅▁▁▃▁▁▁▁▁▃██▅▁▄▅▁▁▃▁▁▄▅▇▇▇▇▆█▇▅▆▅▄▅▄▆▅▄▅▃▅▅▆▃▅▅█▆▅▅▄ █
  26.7 ns      Histogram: log(frequency) by time      29.3 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

